### PR TITLE
Pipx support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setuptools.setup(
     },
     entry_points={
         "console_scripts": ["pypi=pypi_cli.__main__:run"],
+        "pipx.run": ["pypi-command-line=pypi_cli.__main__:run"],
     },
     keywords=[
         "pypi",


### PR DESCRIPTION
For any package that has a different command line interface, pipx run is much more pleasant if you also add an entry point for it. (not needed if the names match). See https://github.com/pipxproject/pipx/issues/600

PS: I'd also recommend moving to setup.cfg, easier to work with and maintain. See https://packaging.python.org or https://scikit-hep.org/developer for examples.